### PR TITLE
Dynamically create rows based on max NSTR

### DIFF
--- a/test.py
+++ b/test.py
@@ -8,7 +8,7 @@ from PyQt6.QtWidgets import (QApplication, QWidget, QVBoxLayout, QLabel,
                              QCheckBox, QComboBox, QGridLayout, QSpinBox, QDoubleSpinBox,
                              QTableWidget, QTableWidgetItem)
 from PyQt6.QtGui import QFont
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, pyqtSignal
 
 class UserDataTab(QWidget):
     """A reusable widget for a single tab with input fields and descriptions."""
@@ -141,6 +141,9 @@ class UserDataTab(QWidget):
 
 class TabularDataTab(QWidget):
     """A widget for a tabular data entry based on a dynamic number of columns."""
+    # Emitted when a numeric cell that affects table structure changes (e.g., NSTR)
+    structureChanged = pyqtSignal()
+
     def __init__(self, row_definitions, tab_name=None, parent=None):
         super().__init__(parent)
         self.row_definitions = row_definitions
@@ -195,6 +198,12 @@ class TabularDataTab(QWidget):
                         spinbox.setDecimals(row_def["decimal_places"])
                         spinbox.setMinimum(row_def.get("min", 0.0))
                         spinbox.setMaximum(row_def.get("max", 999999.0))
+                    # If this is the Structures tab and this numeric row is NSTR, connect signals for real-time update
+                    if self.tab_name == "Structures" and row_def.get("label") == "NSTR":
+                        try:
+                            spinbox.valueChanged.connect(self.structureChanged.emit)
+                        except Exception:
+                            pass
                     self.table.setCellWidget(row_index, col_index, spinbox)
                 elif cell_type == "text":
                     line_edit = QLineEdit()
@@ -319,6 +328,8 @@ class CompactApp(QWidget):
         super().__init__()
         self.setWindowTitle("Compact Data Entry App")
         self.setGeometry(100, 100, 800, 600)
+        # Reentrancy guard for syncs triggered by UI changes
+        self._sync_in_progress = False
         self.tab_data = {
             "Grid Dimensions and General Settings": {
                 "fields": [
@@ -589,6 +600,10 @@ class CompactApp(QWidget):
             self.tab_list.addItem(title)
             self.stacked_widget.addWidget(tab_widget)
         
+        # Connect real-time structure changes from the Structures tab to sync immediately
+        if isinstance(self.tabs.get("Structures"), TabularDataTab):
+            self.tabs["Structures"].structureChanged.connect(self.sync_tabs)
+        
         self.tab_list.currentRowChanged.connect(self.sync_tabs)
 
         self.save_all_button = QPushButton("Save All to CSV")
@@ -608,74 +623,81 @@ class CompactApp(QWidget):
 
     def sync_tabs(self):
         """Syncs data between tabs, particularly for dynamic table sizes."""
-        nwb_value = 0
-        nbr_value = 0
-        grid_tab = self.tabs.get("Grid Dimensions and General Settings")
-        if grid_tab:
-            for label, value in grid_tab.get_data():
-                if label == "NWB" and value:
-                    try:
-                        nwb_value = int(value)
-                    except (ValueError, TypeError):
-                        pass
-                elif label == "NBR" and value:
-                    try:
-                        nbr_value = int(value)
-                    except (ValueError, TypeError):
-                        pass
+        if getattr(self, "_sync_in_progress", False):
+            return
+        self._sync_in_progress = True
+        try:
+            nwb_value = 0
+            nbr_value = 0
+            grid_tab = self.tabs.get("Grid Dimensions and General Settings")
+            if grid_tab:
+                for label, value in grid_tab.get_data():
+                    if label == "NWB" and value:
+                        try:
+                            nwb_value = int(value)
+                        except (ValueError, TypeError):
+                            pass
+                    elif label == "NBR" and value:
+                        try:
+                            nbr_value = int(value)
+                        except (ValueError, TypeError):
+                            pass
 
-        # Sync all NWB-dependent tabs
-        nwb_tabs = ["Timestep Limitations", "Waterbody Definition", "Calculations", "Dead Sea",
-                    "Heat Exchange", "Ice Cover", "Transport Scheme", "Hydaulic Coefficients", "Vertical Eddy Viscosity"]
-        for tab_name in nwb_tabs:
-            tab = self.tabs.get(tab_name)
-            if tab and isinstance(tab, TabularDataTab):
-                current_data = tab.get_data()
-                tab.set_columns(max(1, nwb_value))  # Ensure at least 1 column
-                tab.set_data(current_data)
+            # Sync all NWB-dependent tabs
+            nwb_tabs = ["Timestep Limitations", "Waterbody Definition", "Calculations", "Dead Sea",
+                        "Heat Exchange", "Ice Cover", "Transport Scheme", "Hydaulic Coefficients", "Vertical Eddy Viscosity"]
+            for tab_name in nwb_tabs:
+                tab = self.tabs.get(tab_name)
+                if tab and isinstance(tab, TabularDataTab):
+                    current_data = tab.get_data()
+                    tab.set_columns(max(1, nwb_value))  # Ensure at least 1 column
+                    tab.set_data(current_data)
 
-        # Sync all NBR-dependent tabs
-        nbr_tabs = ["Branch Geometry", "Initial Conditions", "Interpolation", "Structures"]
-        for tab_name in nbr_tabs:
-            tab = self.tabs.get(tab_name)
-            if tab and isinstance(tab, TabularDataTab):
-                current_data = tab.get_data()
-                tab.set_columns(max(1, nbr_value))  # Ensure at least 1 column
-                tab.set_data(current_data)
+            # Sync all NBR-dependent tabs
+            nbr_tabs = ["Branch Geometry", "Initial Conditions", "Interpolation", "Structures"]
+            for tab_name in nbr_tabs:
+                tab = self.tabs.get(tab_name)
+                if tab and isinstance(tab, TabularDataTab):
+                    current_data = tab.get_data()
+                    tab.set_columns(max(1, nbr_value))  # Ensure at least 1 column
+                    tab.set_data(current_data)
 
-        # After NBR-dependent sync, adjust Structures tab rows dynamically based on max NSTR
-        structures_tab = self.tabs.get("Structures")
-        if structures_tab and isinstance(structures_tab, TabularDataTab):
-            try:
-                # Compute maximum NSTR across branches (row labeled 'NSTR')
-                max_nstr = 0
-                # Find index of NSTR row in current definitions (should be 0, but search defensively)
-                nstr_row_index = next((idx for idx, rd in enumerate(structures_tab.row_definitions) if rd.get("label") == "NSTR"), None)
-                if nstr_row_index is not None:
-                    for col_index in range(structures_tab.table.columnCount()):
-                        widget = structures_tab.table.cellWidget(nstr_row_index, col_index)
-                        if isinstance(widget, (QSpinBox, QDoubleSpinBox)):
-                            try:
-                                max_nstr = max(max_nstr, int(widget.value()))
-                            except Exception:
-                                pass
-                # Determine current dynamic rows count beyond the base definitions
-                base_len = len(getattr(structures_tab, 'base_row_definitions', []))
-                current_dynamic = max(0, len(structures_tab.row_definitions) - base_len)
+            # After NBR-dependent sync, adjust Structures tab rows dynamically based on max NSTR
+            structures_tab = self.tabs.get("Structures")
+            if structures_tab and isinstance(structures_tab, TabularDataTab):
+                try:
+                    # Compute maximum NSTR across branches (row labeled 'NSTR')
+                    max_nstr = 0
+                    # Find index of NSTR row in current definitions (should be 0, but search defensively)
+                    nstr_row_index = next((idx for idx, rd in enumerate(structures_tab.row_definitions) if rd.get("label") == "NSTR"), None)
+                    if nstr_row_index is not None:
+                        for col_index in range(structures_tab.table.columnCount()):
+                            widget = structures_tab.table.cellWidget(nstr_row_index, col_index)
+                            if isinstance(widget, (QSpinBox, QDoubleSpinBox)):
+                                try:
+                                    max_nstr = max(max_nstr, int(widget.value()))
+                                except Exception:
+                                    pass
+                    # Determine current dynamic rows count beyond the base definitions
+                    base_len = len(getattr(structures_tab, 'base_row_definitions', []))
+                    current_dynamic = max(0, len(structures_tab.row_definitions) - base_len)
 
-                if max_nstr != current_dynamic:
-                    # Build new row definitions: keep base rows, then add placeholders for each structure
-                    new_rows = list(structures_tab.base_row_definitions)
-                    for i in range(max_nstr):
-                        new_rows.append({
-                            "label": f"STRUCT_{i+1}",
-                            "type": "text",
-                            "description": f"Structure {i+1} parameters for each branch"
-                        })
-                    structures_tab.set_row_definitions(new_rows)
-            except Exception:
-                # Fail-safe: do not break sync if anything unexpected occurs
-                pass
+                    if max_nstr != current_dynamic:
+                        # Build new row definitions: keep base rows, then add placeholders for each structure
+                        new_rows = list(structures_tab.base_row_definitions)
+                        for i in range(max_nstr):
+                            new_rows.append({
+                                "label": f"STRUCT_{i+1}",
+                                "type": "text",
+                                "description": f"Structure {i+1} parameters for each branch"
+                            })
+                        structures_tab.set_row_definitions(new_rows)
+                except Exception:
+                    # Fail-safe: do not break sync if anything unexpected occurs
+                    pass
+        
+        finally:
+            self._sync_in_progress = False
     
     def display_tab(self, item: QListWidgetItem):
         self.sync_tabs()


### PR DESCRIPTION
Add dynamic row creation to the Structures tab based on the maximum NSTR value to accommodate variable structure definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2fa41ed-0b45-4bbe-b0d4-e55c0cbe29af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2fa41ed-0b45-4bbe-b0d4-e55c0cbe29af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

